### PR TITLE
ci: fix codecov upload from main

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,3 +45,4 @@ jobs:
           files: go/coverage.out
           fail_ci_if_error: true
           verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
From codecov-actioin@v4:
> Tokenless uploading is unsupported. However, PRs made from forks to the upstream public repos will support tokenless (e.g. contributors to OS projects do not need the upstream repo's Codecov token)