### PR TITLE
feat: date & timestamp type

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ For example, to open a database to `test_db` by api server at `127.0.0.1:8080`:
 db, err := sql.Open("openmldb", "openmldb://127.0.0.1:8080/test_db")
 ```
 
+`<DB_NAME>` is mandatory in DSN, and at this time (version 0.2.0), you must ensure the database `<DB_NAME>` created before open go connection.
+
 ## Getting Start
 
 ```go

--- a/conn_test.go
+++ b/conn_test.go
@@ -38,7 +38,7 @@ func TestParseReqToJson(t *testing.T) {
 			}`,
 		},
 	} {
-		actual, err := parseReqToJson(tc.mode, tc.sql, tc.input...)
+		actual, err := marshalQueryRequest(tc.mode, tc.sql, tc.input...)
 		assert.NoError(t, err)
 		assert.JSONEq(t, tc.expect, string(actual))
 	}
@@ -102,7 +102,7 @@ func TestParseRespFromJson(t *testing.T) {
 			},
 		},
 	} {
-		actual, err := parseRespFromJson(strings.NewReader(tc.resp))
+		actual, err := unmarshalQueryResponse(strings.NewReader(tc.resp))
 		assert.NoError(t, err)
 		assert.Equal(t, &tc.expect, actual)
 	}

--- a/driver.go
+++ b/driver.go
@@ -3,7 +3,7 @@ package openmldb
 import (
 	"context"
 	"database/sql"
-	interfaces "database/sql/driver"
+	"database/sql/driver"
 	"fmt"
 	"net/url"
 	"strings"
@@ -15,10 +15,10 @@ func init() {
 
 // compile time validation that our types implements the expected interfaces
 var (
-	_ interfaces.Driver        = openmldbDriver{}
-	_ interfaces.DriverContext = openmldbDriver{}
+	_ driver.Driver        = openmldbDriver{}
+	_ driver.DriverContext = openmldbDriver{}
 
-	_ interfaces.Connector = connecter{}
+	_ driver.Connector = connecter{}
 )
 
 type openmldbDriver struct{}
@@ -52,7 +52,7 @@ func parseDsn(dsn string) (host string, db string, mode queryMode, err error) {
 }
 
 // Open implements driver.Driver.
-func (openmldbDriver) Open(name string) (interfaces.Conn, error) {
+func (openmldbDriver) Open(name string) (driver.Conn, error) {
 	// name should be the URL of the api server, e.g. openmldb://localhost:6543/db
 	host, db, mode, err := parseDsn(name)
 	if err != nil {
@@ -63,7 +63,7 @@ func (openmldbDriver) Open(name string) (interfaces.Conn, error) {
 }
 
 // OpenConnector implements driver.DriverContext.
-func (openmldbDriver) OpenConnector(name string) (interfaces.Connector, error) {
+func (openmldbDriver) OpenConnector(name string) (driver.Connector, error) {
 	host, db, mode, err := parseDsn(name)
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ type connecter struct {
 }
 
 // Connect implements driver.Connector.
-func (c connecter) Connect(ctx context.Context) (interfaces.Conn, error) {
+func (c connecter) Connect(ctx context.Context) (driver.Conn, error) {
 	conn := &conn{host: c.host, db: c.db, mode: c.mode, closed: false}
 	if err := conn.Ping(ctx); err != nil {
 		return nil, err
@@ -88,6 +88,6 @@ func (c connecter) Connect(ctx context.Context) (interfaces.Conn, error) {
 }
 
 // Driver implements driver.Connector.
-func (connecter) Driver() interfaces.Driver {
+func (connecter) Driver() driver.Driver {
 	return &openmldbDriver{}
 }

--- a/driver.go
+++ b/driver.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 )
 
+
 func init() {
 	sql.Register("openmldb", &driver{})
 }
-
 var (
 	_ interfaces.Driver        = (*driver)(nil)
 	_ interfaces.DriverContext = (*driver)(nil)

--- a/driver_test.go
+++ b/driver_test.go
@@ -17,7 +17,7 @@ func Test_parseDsn(t *testing.T) {
 	}{
 		{"openmldb://127.0.0.1:8080/test_db", "127.0.0.1:8080", "test_db", ModeOnline, nil},
 		{"openmldb://127.0.0.1:8080/test_db?mode=online", "127.0.0.1:8080", "test_db", ModeOnline, nil},
-		{"openmldb://127.0.0.1:8080/test_db?mode=offasync", "127.0.0.1:8080", "test_db", ModeOffasync, nil},
+		{"openmldb://127.0.0.1:8080/test_db?mode=offline", "127.0.0.1:8080", "test_db", ModeOffline, nil},
 		{"openmldb://127.0.0.1:8080/test_db?mode=unknown", "127.0.0.1:8080", "test_db", "", errors.New("")},
 	} {
 		host, db, mode, err := parseDsn(tc.dsn)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/4paradigm/openmldb-go-sdk
 
 go 1.18
 
-require github.com/stretchr/testify v1.8.0
+require github.com/stretchr/testify v1.9.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,15 +1,10 @@
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go_sdk_test.go
+++ b/go_sdk_test.go
@@ -8,10 +8,12 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	// register openmldb driver
-	_ "github.com/4paradigm/openmldb-go-sdk"
 	"github.com/stretchr/testify/assert"
+
+	openmldb "github.com/4paradigm/openmldb-go-sdk"
 )
 
 var apiServer string
@@ -32,7 +34,7 @@ func Test_driver(t *testing.T) {
 	assert.NoError(t, db.PingContext(ctx), "fail to ping connect")
 
 	{
-		createTableStmt := "CREATE TABLE demo(c1 int, c2 string);"
+		createTableStmt := "CREATE TABLE demo(c1 int, c2 string, ts timestamp, dt date);"
 		_, err := db.ExecContext(ctx, createTableStmt)
 		assert.NoError(t, err, "fail to exec %s", createTableStmt)
 	}
@@ -47,28 +49,32 @@ func Test_driver(t *testing.T) {
 
 	{
 		// FIXME: ordering issue
-		insertValueStmt := `INSERT INTO demo VALUES (1, "bb");`
+		insertValueStmt := `INSERT INTO demo VALUES (1, "bb", 3000, "2022-12-12");`
 		// insertValueStmt := `INSERT INTO demo VALUES (1, "bb"), (2, "bb");`
 		_, err := db.ExecContext(ctx, insertValueStmt)
 		assert.NoError(t, err, "fail to exec %s", insertValueStmt)
 	}
 
 	t.Run("query", func(t *testing.T) {
-		queryStmt := `SELECT c1, c2 FROM demo`
+		queryStmt := `SELECT * FROM demo`
 		rows, err := db.QueryContext(ctx, queryStmt)
 		assert.NoError(t, err, "fail to query %s", queryStmt)
 
 		var demo struct {
 			c1 int32
 			c2 string
+			ts time.Time
+			dt openmldb.NullDate
 		}
 		{
 			assert.True(t, rows.Next())
-			assert.NoError(t, rows.Scan(&demo.c1, &demo.c2))
+			assert.NoError(t, rows.Scan(&demo.c1, &demo.c2, &demo.ts, &demo.dt))
 			assert.Equal(t, struct {
 				c1 int32
 				c2 string
-			}{1, "bb"}, demo)
+				ts time.Time
+				dt openmldb.NullDate
+			}{1, "bb", time.UnixMilli(3000), openmldb.NullDate{Time: time.Date(2022, time.December, 12, 0, 0, 0, 0, time.UTC), Valid: true}}, demo)
 		}
 		// {
 		// 	assert.True(t, rows.Next())

--- a/go_sdk_test.go
+++ b/go_sdk_test.go
@@ -18,6 +18,9 @@ import (
 
 var apiServer string
 
+// 1. NullTime + NullDate
+// 2. Time + Time
+
 func Test_driver(t *testing.T) {
 	db, err := sql.Open("openmldb", fmt.Sprintf("openmldb://%s/test_db", apiServer))
 	if err != nil {

--- a/types.go
+++ b/types.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	_ sql.Scanner = (*NullDate)(nil)
+	_ driver.Valuer = NullDate{}
 )
 
 type NullDate struct {
@@ -38,7 +39,7 @@ func (dt *NullDate) Scan(src any) error {
 
 }
 
-// Value implements driver.Value for NullDate
+// Value implements driver.Valuer for NullDate
 func (dt NullDate) Value() (driver.Value, error) {
 	if !dt.Valid {
 		return nil, nil

--- a/types.go
+++ b/types.go
@@ -1,0 +1,48 @@
+package openmldb
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"time"
+)
+
+var (
+	_ sql.Scanner = (*NullDate)(nil)
+)
+
+type NullDate struct {
+	Time  time.Time
+	Valid bool // Valid is true if Time is not NULL
+}
+
+// Scan implements sql.Scanner for NullDate
+func (dt *NullDate) Scan(src any) error {
+	switch val := src.(type) {
+	case string:
+		dval, err := time.Parse(time.DateOnly, val)
+		if err != nil {
+			dt.Valid = false
+			return err
+		} else {
+			dt.Time = dval
+			dt.Valid = true
+			return nil
+		}
+	case NullDate:
+		*dt = val
+		return nil
+	default:
+		return errors.New("scan NullDate from unsupported type")
+	}
+
+}
+
+// Value implements driver.Value for NullDate
+func (dt NullDate) Value() (driver.Value, error) {
+	if !dt.Valid {
+		return nil, nil
+	}
+	return dt.Time, nil
+
+}


### PR DESCRIPTION
1. support date & timestamp type
   you can use `time.Time` to represent SQL timestamp type, and `openmldb.NullDate` to represent date type
2. simply `mode` in DSN
    only `online` & `offline`, and later option `request`, rm `offsync` or `offasync`
3. deps: upgrade testify to v1.9.0